### PR TITLE
docs: update vllm startup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Please refer to the `trans_infer_cli.py` code in the `inference` folder.
 ```shell
 vllm serve zai-org/GLM-4.5-Air \
     --tensor-parallel-size 8 \
-    --tool-call-parser glm45 \
-    --reasoning-parser glm45 \
+    --tool-call-parser glm4_moe \
+    --reasoning-parser glm4_moe \
     --enable-auto-tool-choice \
     --served-model-name glm-4.5-air
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -118,8 +118,8 @@ pip install -r requirements.txt
 ```shell
 vllm serve zai-org/GLM-4.5-Air \
     --tensor-parallel-size 8 \
-    --tool-call-parser glm45 \
-    --reasoning-parser glm45 \
+    --tool-call-parser glm4_moe \
+    --reasoning-parser glm4_moe \
     --enable-auto-tool-choice \
     --served-model-name glm-4.5-air
 ```


### PR DESCRIPTION
vllm 0.10.0 does not support `--tool-call-parser glm45` and `--reasoning-parser glm45`. Modifying them to 'glm4_moe' will start the service.