### PR TITLE
docs(ascend): fix Python library path

### DIFF
--- a/example/Ascend_NPU/README_zh.md
+++ b/example/Ascend_NPU/README_zh.md
@@ -90,7 +90,7 @@ for i in range(16):torch_npu.npu.set_device(i)"
 ```bash
 ##### 1， 配置依赖路径相关环境变量
 export PYTHON_INCLUDE_PATH="$(python3 -c 'from sysconfig import get_paths; print(get_paths()["include"])')"
-export PYTHON_LIB_PATH="$(python3 -c 'from sysconfig import get_paths; print(get_paths()["include"])')"
+export PYTHON_LIB_PATH="$(python3 -c 'from sysconfig import get_config_var; print(get_config_var("LIBDIR"))')"
 export PYTORCH_NPU_INSTALL_PATH=/usr/local/libtorch_npu/
 export PYTORCH_INSTALL_PATH="$(python3 -c 'import torch, os; print(os.path.dirname(os.path.abspath(torch.__file__)))')"
 export LIBTORCH_ROOT="$(python3 -c 'import torch, os; print(os.path.dirname(os.path.abspath(torch.__file__)))')"


### PR DESCRIPTION
## What changed

The Ascend setup guide now derives `PYTHON_LIB_PATH` from Python's configured `LIBDIR` instead of reusing the header include path.

This keeps `PYTHON_INCLUDE_PATH` pointed at headers while giving the downstream linker an actual library directory.

## Verification

- Evaluated the command locally and confirmed `LIBDIR` resolves to the platform library directory
- Checked the shell quoting with `bash -n`
- `git diff --check`

Fixes #137
